### PR TITLE
Install APCu stable version

### DIFF
--- a/2.0/apache/Dockerfile
+++ b/2.0/apache/Dockerfile
@@ -23,7 +23,7 @@ RUN apt-get update \
     && docker-php-ext-install mbstring \
     && docker-php-ext-install mcrypt \
     && docker-php-ext-install zip \
-    && pecl install apcu-beta && echo extension=apcu.so > /usr/local/etc/php/conf.d/apcu.ini \
+    && pecl install apcu && echo extension=apcu.so > /usr/local/etc/php/conf.d/apcu.ini \
 
     && apt-get purge -y g++ \
     && apt-get autoremove -y \


### PR DESCRIPTION
APCu is now shipped on two channels, beta and stable.

The beta version is for PHP 7, the stable version PHP 5.3+.
